### PR TITLE
Fix loading stylesheets

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -588,8 +588,12 @@ class Dompdf
             switch (strtolower($tag->nodeName)) {
                 // load <link rel="STYLESHEET" ... /> tags
                 case "link":
-                    if (mb_strtolower(stripos($tag->getAttribute("rel"), "stylesheet") !== false) || // may be "appendix stylesheet"
-                        mb_strtolower($tag->getAttribute("type")) === "text/css"
+                    if (
+                        (
+                            stripos(mb_strtolower($tag->getAttribute("rel")), "stylesheet") !== false // may be "appendix stylesheet"
+                            && stripos(mb_strtolower($tag->getAttribute("rel")),"alternate") === false // don't load "alternate stylesheet"
+                        )
+                        || mb_strtolower($tag->getAttribute("type")) === "text/css"
                     ) {
                         //Check if the css file is for an accepted media type
                         //media not given then always valid


### PR DESCRIPTION
- Fix bug with loading stylesheets with `rel="STYLESHEET"`, `rel="Stylesheet"` and etc. (Introduced in dompdf/dompdf@6fb7227)
- Don't load alternate stylesheets because they should be disabled by default (https://www.w3.org/Style/Examples/007/alternatives.en.html, https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets#details)